### PR TITLE
Change update to updateOne

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cache-manager-mongoose",
-  "version": "0.0.4",
+  "name": "cache-manager-mongoose-v2",
+  "version": "1.0.0",
   "description": "mongoose store for node-cache-manager",
   "main": "src/index.js",
   "scripts": {
@@ -11,11 +11,11 @@
     "mongoose",
     "cache manager"
   ],
-  "author": "Konstantin Pogorelov <or@pluseq.com>",
+  "author": "Konstantin Pogorelov <or@pluseq.com>, Taavi Ilves <ilves.taavi@gmail.com>",
   "license": "WTFPL",
   "repository": {
     "type": "git",
-    "url": "https://github.com/disjunction/node-cache-manager-mongoose.git"
+    "url": "https://github.com/ilves/node-cache-manager-mongoose.git"
   },
   "devDependencies": {
     "cache-manager": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cache-manager-mongoose-v2",
-  "version": "1.0.0",
+  "name": "cache-manager-mongoose",
+  "version": "0.0.4",
   "description": "mongoose store for node-cache-manager",
   "main": "src/index.js",
   "scripts": {
@@ -11,11 +11,11 @@
     "mongoose",
     "cache manager"
   ],
-  "author": "Konstantin Pogorelov <or@pluseq.com>, Taavi Ilves <ilves.taavi@gmail.com>",
+  "author": "Konstantin Pogorelov <or@pluseq.com>",
   "license": "WTFPL",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ilves/node-cache-manager-mongoose.git"
+    "url": "https://github.com/disjunction/node-cache-manager-mongoose.git"
   },
   "devDependencies": {
     "cache-manager": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ class MongooseStore {
                 doc.exp = new Date(Date.now() + ttl * 1000);
             }
 
-            return this.model.update(
+            return this.model.updateOne(
                 {_id: key},
                 doc,
                 {upsert: true}

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -10,7 +10,7 @@ let mongoose = require("mongoose-mock"),
 describe("cache-manager-mongoose", function() {
     let modelStub = {
         testProp: true,
-        update: () => Promise.resolve(),
+        updateOne: () => Promise.resolve(),
         findOne: () => Promise.resolve(),
         remove: () => Promise.resolve()
     };
@@ -73,7 +73,7 @@ describe("cache-manager-mongoose", function() {
             store: cmm,
             model: modelStub
         });
-        let spy = this.stub(modelStub, "update");
+        let spy = this.stub(modelStub, "updateOne");
         cache.set("someKey", "someValue", null, function () {
             sinon.assert.calledOnce(spy);
             done();
@@ -86,7 +86,7 @@ describe("cache-manager-mongoose", function() {
             model: modelStub,
             ttl: 0
         });
-        let spy = this.stub(modelStub, "update");
+        let spy = this.stub(modelStub, "updateOne");
         cache.set("someKey", "someValue", null, function () {
             sinon.assert.calledOnce(spy);
             done();


### PR DESCRIPTION
Calling update with current mongoose version displays deprecation warning. Should use updateOne instead.